### PR TITLE
Fix for double occurrence of the time bins and add noise to signal

### DIFF
--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
@@ -39,6 +39,10 @@ class DigitizerTask : public FairTask{
     /// \param debugsString String containing the debug flags
     ///        o PRFdebug - Debug output after application of the PRF
     void setDebugOutput(TString debugString);
+
+    /// Set the maximal number of written out time bins
+    /// \param nTimeBinsMax Maximal number of time bins to be written out
+    void setMaximalTimeBinWriteOut(int i) { mTimeBinMax = i; }
       
     /// Digitization
     /// \param option Option
@@ -56,6 +60,8 @@ class DigitizerTask : public FairTask{
     TClonesArray        *mDigitsArray;  ///< Array of the Digits, passed from the digitization
     
     std::string         mHitFileName;  ///< External hit file exported from AliRoot
+
+    int                 mTimeBinMax;   ///< Maximum time bin to be written out
 
   ClassDefOverride(DigitizerTask, 1);
 };

--- a/Detectors/TPC/simulation/src/DigitPad.cxx
+++ b/Detectors/TPC/simulation/src/DigitPad.cxx
@@ -4,6 +4,9 @@
 
 #include "TPCSimulation/DigitPad.h"
 #include "TPCSimulation/SAMPAProcessing.h"
+#include "TPCBase/PadPos.h"
+#include "TPCBase/PadSecPos.h"
+#include "TPCBase/CRU.h"
 #include "TPCSimulation/DigitMC.h"
 
 #include <boost/range/adaptor/reversed.hpp>
@@ -14,11 +17,10 @@ using namespace AliceO2::TPC;
 void DigitPad::fillOutputContainer(TClonesArray *output, int cru, int timeBin, int row, int pad, float commonMode)
 {
   /// The charge accumulated on that pad is converted into ADC counts, saturation of the SAMPA is applied and a Digit is created in written out
-  const SAMPAProcessing& sampa = SAMPAProcessing::instance();
-  float totalADC = mChargePad;
+  const float totalADC = mChargePad - commonMode; // common mode is subtracted here in order to properly apply noise, pedestals and saturation of the SAMPA
   std::vector<long> MClabel;
   processMClabels(MClabel);
-  const float mADC = sampa.getADCSaturation(totalADC-commonMode); // we substract the common mode here in order to properly apply the saturation of the FECs
+  const float mADC = SAMPAProcessing::makeSignal(totalADC, PadSecPos(CRU(cru).sector(), PadPos(row, pad)));
   if(mADC > 0) {
     TClonesArray &clref = *output;
     new(clref[clref.GetEntriesFast()]) DigitMC(MClabel, cru, mADC, row, pad, timeBin, commonMode);

--- a/Detectors/TPC/simulation/src/DigitizerTask.cxx
+++ b/Detectors/TPC/simulation/src/DigitizerTask.cxx
@@ -28,6 +28,7 @@ DigitizerTask::DigitizerTask()
   , mPointsArray(nullptr)
   , mDigitsArray(nullptr)
   , mHitFileName()
+  , mTimeBinMax(1000000)
 {
   /// \todo get rid of new
   mDigitizer = new Digitizer;
@@ -88,18 +89,14 @@ void DigitizerTask::Exec(Option_t *option)
   mDigitsArray->Delete();
   mDigitContainer = mDigitizer->Process(mPointsArray);
   mDigitContainer->fillOutputContainer(mDigitsArray, eventTime);
-  mgr->Fill();
-//  std::vector<CommonMode> commonModeContainer(0);
-//  digits->processCommonMode(commonModeContainer);
-//  digits->fillOutputContainer(mDigitsArray, commonModeContainer);
 }
 
 void DigitizerTask::FinishTask()
 {
   FairRootManager *mgr = FairRootManager::Instance();
+  mgr->SetLastFill(kTRUE); /// necessary, otherwise the data is not written out
   mDigitsArray->Delete();
-  mDigitContainer->fillOutputContainer(mDigitsArray, 1000000);
-  mgr->Fill();
+  mDigitContainer->fillOutputContainer(mDigitsArray, mTimeBinMax);
 }
 
 void DigitizerTask::fillHitArrayFromFile()

--- a/macro/run_digi_tpc.C
+++ b/macro/run_digi_tpc.C
@@ -60,7 +60,6 @@ void run_digi_tpc(Int_t nEvents = 10, TString mcEngine = "TGeant3"){
 
         timer.Start();
         run->Run();
-        run->TerminateRun();
 
         std::cout << std::endl << std::endl;
 


### PR DESCRIPTION
o The double occurrence of the time bins was caused by FairRunAna::Terminate() being called in addition in tpc_run_digi.C. Additionally FairRootManager::Fill() was executed manually
  - Please note that running 10 events results in 11 events written to disk, out of which the first is empty. There is no straight-forward solution for this at the moment, as all this is handled within FairRoot

o Noise is now added to the signal in SampaProcessing::MakeSignal()
  - baseline.h offers no Pedestal values yet, so those are not applied
