### PR TITLE
Dev time flagging

### DIFF
--- a/DataFormats/Analysis/include/DataFormatsAnalysis/TimeRangeFlagsCollection.h
+++ b/DataFormats/Analysis/include/DataFormatsAnalysis/TimeRangeFlagsCollection.h
@@ -55,6 +55,9 @@ class TimeRangeFlagsCollection
   /// write data to ostream
   void streamTo(std::ostream& output) const;
 
+  // merging functionality
+  void merge(TimeRangeFlagsCollection<time_type, bitmap_type> trfc);
+
   /// overloading output stream operator
   friend std::ostream& operator<<(std::ostream& output, const TimeRangeFlagsCollection& data)
   {

--- a/DataFormats/Analysis/macros/testTimeRangeFlagsCollectionMerge.C
+++ b/DataFormats/Analysis/macros/testTimeRangeFlagsCollectionMerge.C
@@ -1,0 +1,69 @@
+#include <iostream>
+
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DataFormatsAnalysis/FlagReasons.h"
+#include "DataFormatsAnalysis/TimeRangeFlagsCollection.h"
+#include "CCDB/CcdbApi.h"
+
+using namespace o2::analysis;
+
+using time_type = uint64_t;
+using o2::detectors::DetID;
+using o2::ccdb::CcdbApi;
+
+void testTime(DetID detID, time_type time, const TimeRangeFlagsCollection<time_type>& coll);
+
+void testTimeRangeFlagsCollectionMerge()
+{
+  // ===| set up reasons |======================================================
+  auto& reasons = FlagReasons::instance();
+  reasons.addReason("Bad");
+  reasons.addReason("Bad for PID");
+  reasons.addReason("Limited acceptance");
+  reasons.print();
+  std::cout << "\n";
+
+  // ===| set up mask ranges |==================================================
+  TimeRangeFlagsCollection<time_type, uint16_t> coll1;
+  coll1.addTimeRangeFlags(DetID::ITS, 0, 50, 1);
+  coll1.addTimeRangeFlags(DetID::ITS, 51, 100, 4); 
+  coll1.addTimeRangeFlags(DetID::TPC, 0, 9, 6);
+  TimeRangeFlagsCollection<time_type, uint16_t> coll2;
+  coll2.addTimeRangeFlags(DetID::TPC, 0, 1, 6);
+  coll2.addTimeRangeFlags(DetID::TPC, 10, 100, 4);
+
+  printf("Collection one:\n");
+  coll1.print();
+  std::cout << "\n";
+  printf("Collection two:\n");
+  coll2.print();
+
+  // ===| test if time has flags |==============================================
+  std::cout << "==================| check times for flags |====================\n";
+  std::cout << "                     " << DetID(DetID::ITS).getName() << "\n";
+  testTime(DetID::ITS, 2, coll1);
+  testTime(DetID::ITS, 50, coll1);
+  std::cout << "\n";
+
+  std::cout << "                     " << DetID(DetID::TPC).getName() << "\n";
+  testTime(DetID::TPC, 2, coll2);
+  testTime(DetID::TPC, 50, coll2);
+
+  coll2.merge(coll1);
+  std::cout << "\n";
+  printf("NEW Collection two:\n");
+  coll2.print();
+  
+
+}
+
+void testTime(DetID detID, time_type time, const TimeRangeFlagsCollection<time_type>& coll)
+{
+  const TimeRangeFlags<time_type>* flags{nullptr};
+  if ((flags = coll.findTimeRangeFlags(detID, time))) {
+    std::cout << "Time " << time << " has the flags: " << flags->collectMaskReasonNames() << "\n";
+  } else {
+    std::cout << "Time " << time << " has NO flags\n";
+  }
+}
+

--- a/DataFormats/Analysis/src/TimeRangeFlagsCollection.cxx
+++ b/DataFormats/Analysis/src/TimeRangeFlagsCollection.cxx
@@ -64,4 +64,36 @@ void TimeRangeFlagsCollection<time_type, bitmap_type>::streamTo(std::ostream& ou
   }
 }
 
+template <typename time_type, typename bitmap_type>
+void TimeRangeFlagsCollection<time_type, bitmap_type>::merge(TimeRangeFlagsCollection<time_type, bitmap_type> trfc)
+{
+
+  // method to merge two TimeRangeFlagsCollection objects
+  // we assume that the meaning of the same bit is the same for the two collections (--> same definition of reasons)
+  
+  for (DetID::ID id = 0; id < mTimeRangeFlagsCollection.size(); ++id) {
+    const auto& timeRangeDet = mTimeRangeFlagsCollection[id]; // returns the TimeRangeFlagsColl for index id
+    if (!timeRangeDet.size()) { // this detector for now had no reasons
+      // we copy the content of the collection to be merged
+      mTimeRangeFlagsCollection[id] = trfc.mTimeRangeFlagsCollection[id];
+    }
+    else {
+      for (auto& timeRange : mTimeRangeFlagsCollection[id]) {
+	auto startTime = timeRange.getStart();
+	auto endTime = timeRange.getEnd();
+	for (const auto& timeRangecmp : trfc.mTimeRangeFlagsCollection[id]) {
+	  if (timeRange.getFlags() == timeRangecmp.getFlags()) { // we need to extend the validity of this flag
+	    auto startTimecmp = timeRangecmp.getStart();
+	    auto endTimecmp = timeRangecmp.getEnd();
+	    startTime = std::min(startTime, startTimecmp);
+	    endTime = std::max(endTime, endTimecmp);
+	    timeRange.setStart(startTime);
+	    timeRange.setEnd(endTime);
+	  }
+	}
+      }
+    }
+  }
+}
+
 template class TimeRangeFlagsCollection<uint64_t>;


### PR DESCRIPTION
Hello Jens, 

This is the proposal for an implementation of the merge functionality for the TimeRangeFlagsCollections. 
It adds new ranges, if the one to be merged did not exist, otherwise it extends the validity of the existing one (they can be merged only if the flags are exactly the same - if not, they are considered as different, since I understood that when a period has two flags, it will appear as one single TimeRange with two bits on). 

Let me know if you think it can work like this. 

Chiara
